### PR TITLE
Bugfix for regression in association filters

### DIFF
--- a/lib/tabulatr/tabulatr/finder/find_for_table.rb
+++ b/lib/tabulatr/tabulatr/finder/find_for_table.rb
@@ -141,7 +141,7 @@ module Tabulatr::Finder
           assoc, att = n.split(".").map(&:to_sym)
           r = klaz.reflect_on_association(assoc)
           includes << assoc
-          table_name = (typ==:ar ? klaz.table_name : klaz.to_s.tableize)
+          table_name = (typ==:ar ? r.table_name : r.to_s.tableize)
           nn = "#{table_name}.#{att}"
           rel = condition_from(rel, typ, nn, v)
         end


### PR DESCRIPTION
Fix for broken association filters - want to use the association table name, not the main table name
