### PR TITLE
Compound filters

### DIFF
--- a/lib/tabulatr/tabulatr/adapter/active_record.rb
+++ b/lib/tabulatr/tabulatr/adapter/active_record.rb
@@ -37,9 +37,9 @@ class Tabulatr::Adapter::ActiveRecordAdapter < Tabulatr::Adapter
     prefix = "#{prefix}." if prefix
 
     if String === opts
-      query = columns.map {|field| "\"#{prefix}#{field}\" = #{opts}"}.join(" OR ")
+      query = columns.map {|field| "#{prefix}#{field} = #{opts}"}.join(" OR ")
     elsif Hash === opts
-      query = columns.map {|field| "\"#{prefix}#{field}\" #{like} \"%#{opts[:like]}%\""}.join(" OR ") unless opts[:like].blank?
+      query = columns.map {|field| "#{prefix}#{field} #{like} \"%#{opts[:like]}%\""}.join(" OR ") unless opts[:like].blank?
     else
       raise "Wrong filter type: #{opts.class}"
     end
@@ -52,7 +52,15 @@ class Tabulatr::Adapter::ActiveRecordAdapter < Tabulatr::Adapter
   end
 
   def includes!(inc)
-    @relation = includes(includes)
+    @relation = includes(inc)
+  end
+
+  def joins(inc)
+    @relation.joins(inc)
+  end
+
+  def joins!(inc)
+    @relation = joins(inc)
   end
 
   def add_conditions_from(n,v)

--- a/lib/tabulatr/tabulatr/adapter/active_record.rb
+++ b/lib/tabulatr/tabulatr/adapter/active_record.rb
@@ -31,6 +31,22 @@ class Tabulatr::Adapter::ActiveRecordAdapter < Tabulatr::Adapter
     context.values.join(" ") if context
   end
 
+  def add_compound_query(columns, opts, prefix=nil)
+    like ||= Tabulatr.sql_options[:like]
+
+    prefix = "#{prefix}." if prefix
+
+    if String === opts
+      query = columns.map {|field| "\"#{prefix}#{field}\" = #{opts}"}.join(" OR ")
+    elsif Hash === opts
+      query = columns.map {|field| "\"#{prefix}#{field}\" #{like} \"%#{opts[:like]}%\""}.join(" OR ") unless opts[:like].blank?
+    else
+      raise "Wrong filter type: #{opts.class}"
+    end
+
+    @relation = @relation.where(query) if query
+  end
+
   def includes(inc)
     @relation.includes(inc)
   end

--- a/lib/tabulatr/tabulatr/data_cell.rb
+++ b/lib/tabulatr/tabulatr/data_cell.rb
@@ -36,6 +36,7 @@ class Tabulatr
   def data_column(name, opts={}, &block)
     raise "Not in data mode!" if @row_mode != :data
     opts = normalize_column_options opts
+
     make_tag(:td, opts[:td_html]) do
       href = if opts[:link].class == Symbol || opts[:link].class == String
           @view.send(opts[:link], @record)
@@ -44,11 +45,17 @@ class Tabulatr
         else
           nil
         end
+
+      name = opts[:method] if opts[:method]
       make_tag((href ? :a : nil), :href => href) do
         if block_given?
           concat(yield(@record))
+        elsif Array === name
+          name.map do |field|
+            @record.send(field)
+          end.join(", ")
         else
-          val = @record.send(opts[:method] || name)
+          val = @record.send(name)
           format = opts[:format]
           concat(
             if format.is_a?(Proc) then format.call(val)
@@ -74,36 +81,45 @@ class Tabulatr
   def data_association(relation, name, opts={}, &block)
     raise "Not in data mode!" if @row_mode != :data
     opts = normalize_column_options opts
+
     if block_given?
       return yield(@record)
     end
+
     assoc = @record.class.reflect_on_association(relation)
+
     make_tag(:td, opts[:td_html]) do
-      format = opts[:format]
       ass = @record.send(relation.to_sym)
       if opts[:sort_by]
         # TODO: SORTING specified by opts[:sort_by]
       end
-      concat(if (ass.is_a?(Array) or assoc.collection?) and opts[:map]
-        ass.map do |r|
-          val = h(r.send(opts[:method] || name))
-          if format.is_a?(Proc) then format.call(val)
-          elsif format.is_a?(String) then h(format % val)
-          elsif format.is_a?(Symbol) then Tabulatr::Formattr.format(format, val)
-          else h(val.to_s)
-          end
-        end.join(opts[:join_symbol])
+
+      if (ass.is_a?(Array) or assoc.collection?) and opts[:map]
+        results = ass.map {|r| association_format_helper(r, opts, name) }.join(opts[:join_symbol])
       else
-        return '' unless ass
-        #puts ass.to_s
-        val = h(ass.send(opts[:method] || name))
-        val = if format.is_a?(Proc) then format.call(val)
-        elsif format.is_a?(String) then h(format % val)
-        elsif format.is_a?(Symbol) then Tabulatr::Formattr.format(format, val)
-        else h(val.to_s)
-        end
-      end)
+        results = (ass ? association_format_helper(ass, opts, name) : '')
+      end
+
+      concat(results)
     end # </td>
+  end
+
+  def association_format_helper(r, opts, name)
+    format = opts[:format]
+
+    name = opts[:method] if opts[:method].present?
+
+    if Array === name
+      val = h(name.map {|field| r.send(field)}.join(', '))
+    else
+      val = h(r.send(name))
+    end
+
+    if format.is_a?(Proc) then format.call(val)
+    elsif format.is_a?(String) then h(format % val)
+    elsif format.is_a?(Symbol) then Tabulatr::Formattr.format(format, val)
+    else h(val.to_s)
+    end
   end
 
   def data_checkbox(opts={}, &block)

--- a/lib/tabulatr/tabulatr/filter_cell.rb
+++ b/lib/tabulatr/tabulatr/filter_cell.rb
@@ -39,7 +39,10 @@ class Tabulatr
   def filter_column(name, opts={}, &block)
     raise "Not in filter mode!" if @row_mode != :filter
     opts = normalize_column_options(opts)
+
+    name = name.map(&:to_s).join(',') if (Array === name)
     value = @filters[name]
+
     make_tag(:td, opts[:filter_html]) do
       of = opts[:filter]
       iname = "#{@classname}#{@table_form_options[:filter_postfix]}[#{name}]"
@@ -64,10 +67,14 @@ class Tabulatr
     raise "Not in filter mode!" if @row_mode != :filter
     opts = normalize_column_options(opts)
     filters = (@filters[@table_form_options[:associations_filter]] || {})
+
+
+    name = name.map(&:to_s).join(',') if (Array === name)
     value = filters["#{relation}.#{name}"]
+
     make_tag(:td, opts[:filter_html]) do
       of = opts[:filter]
-      iname = "#{@classname}#{@table_form_options[:filter_postfix]}[#{@table_form_options[:associations_filter]}][#{relation}.#{name}]"
+      iname = "#{@classname}#{@table_form_options[:filter_postfix]}[#{@table_form_options[:associations_filter]}][#{relation}][#{name}]"
       filter_tag(of, iname, value, opts)
     end # </td>
   end

--- a/lib/tabulatr/tabulatr/finder/find_for_table.rb
+++ b/lib/tabulatr/tabulatr/finder/find_for_table.rb
@@ -127,7 +127,7 @@ module Tabulatr::Finder
       # TODO: Refactor. code duplication
       if (n != form_options[:associations_filter])
         if n.include? ","
-          adapter.add_compound_query(n.split(','), v)
+          adapter.add_compound_query(n.split(','), v, adapter.table_name)
         else
           query = maps[n]
 
@@ -185,7 +185,7 @@ module Tabulatr::Finder
     page += 1 if paginate_options[:page_right]
     page -= 1 if paginate_options[:page_left]
 
-    c = adapter.includes(includes).count
+    c = adapter.includes!(includes).count
     # Group statments return a hash
     c = c.count unless c.class == Fixnum
 
@@ -195,7 +195,6 @@ module Tabulatr::Finder
     total = adapter.preconditions_scope(opts).count
     # here too
     total = total.count unless total.class == Fixnum
-
 
     # Now, actually find the stuff
     found = adapter.limit(pagesize.to_i).offset(((page-1)*pagesize).to_i).order(order).to_a

--- a/lib/tabulatr/tabulatr/finder/find_for_table.rb
+++ b/lib/tabulatr/tabulatr/finder/find_for_table.rb
@@ -64,6 +64,7 @@ module Tabulatr::Finder
       yield(Invoker.new(batch_param, selected_ids))
     end
 
+
     # then, we obey any "select" buttons if pushed
     if checked_param[:select_all]
       selected_ids = adapter.selected_ids(opts).to_a.map { |r| r.send(id) }
@@ -119,30 +120,47 @@ module Tabulatr::Finder
     maps = opts[:name_mapping] || {}
     conditions = filter_param.each do |t|
       n, v = t
+
       next unless v.present?
       # FIXME n = name_escaping(n)
+
+      # TODO: Refactor. code duplication
       if (n != form_options[:associations_filter])
-        table_name = adapter.table_name
-        nn = if maps[n] then maps[n] else
-          t = "#{table_name}.#{n}"
-          raise "SECURITY violation, field name is '#{t}'" unless /^[\d\w]+(\.[\d\w]+)?$/.match t
-          t
+        if n.include? ","
+          adapter.add_compound_query(n.split(','), v)
+        else
+          query = maps[n]
+
+          unless query
+            query ||= "#{adapter.table_name}.#{n}"
+            raise "SECURITY violation, field name is '#{t}'" unless /^[\d\w]+(\.[\d\w]+)?$/.match query
+          end
+
+          adapter.add_conditions_from(query, v)
         end
-        # puts ">>>>>1>> #{n} -> #{nn}"
-        adapter.add_conditions_from(nn, v)
       else
         v.each do |t|
-          n,v = t
-          assoc, att = n.split(".").map(&:to_sym)
-          includes << assoc
-          table_name = adapter.table_name_for_association(assoc)
-          nn = if maps[n] then maps[n] else
-            t = "#{table_name}.#{att}"
-            raise "SECURITY violation, field name is '#{t}'" unless /^[\d\w]+(\.[\d\w]+)?$/.match t
-            t
+          assoc, values = t
+
+
+          includes << assoc.to_sym
+          table_name = adapter.table_name_for_association(assoc.to_sym)
+
+          field = values.keys.first
+          if field.include? ","
+            adapter.add_compound_query(field.split(','), values.values.first, table_name)
+          else
+            values.each_key do |field|
+              query = maps[field]
+
+              unless query
+                query = "#{table_name}.#{field}"
+                raise "SECURITY violation, field name is '#{query}'" unless /^[\d\w]+(\.[\d\w]+)?$/.match query
+              end
+
+              adapter.add_conditions_from(query, values)
+            end
           end
-          # puts ">>>>>2>> #{n} -> #{nn}"
-          adapter.add_conditions_from(nn, v)
         end
       end
     end

--- a/spec/dummy_app/app/controllers/products_controller.rb
+++ b/spec/dummy_app/app/controllers/products_controller.rb
@@ -21,6 +21,10 @@ class ProductsController < ApplicationController
     @products = Product.find_for_table(params)
   end
 
+  def index_compound
+    @products = Product.find_for_table(params)
+  end
+
   def index_stateful
     @products = Product.find_for_table(params, :stateful => session)
   end

--- a/spec/dummy_app/app/views/products/index_compound.html.erb
+++ b/spec/dummy_app/app/views/products/index_compound.html.erb
@@ -1,0 +1,5 @@
+<%= table_for @products do |t|
+  t.column [:title, :description], :filter => :like, :compound_with => :or
+  t.association :vendor, [:name, :description], :filter => :like, :compound_with => :and
+end %>
+

--- a/spec/dummy_app/config/routes.rb
+++ b/spec/dummy_app/config/routes.rb
@@ -6,6 +6,7 @@ DummyApp::Application.routes.draw do
     collection do
        get :index_simple
        get :index_filters
+       get :index_compound
        get :index_select
        get :index_sort
        get :index_stateful

--- a/spec/requests/tabulatrs_spec.rb
+++ b/spec/requests/tabulatrs_spec.rb
@@ -15,14 +15,14 @@ describe "Tabulatrs" do
   "occaecat", "cupidatat", "non", "proident", "sunt", "culpa", "qui",
   "officia", "deserunt", "mollit", "anim", "est", "laborum"]
 
-  let(:vendor1) { Vendor.create!(:name => "ven d'or", :active => true, :description => "blarg") }
-  let(:vendor2) { Vendor.create!(:name => 'producer', :active => true, :description => "vendor extrordinare") }
-  let(:tag1)    { Tag.create!(:title => 'foo') }
-  let(:tag2)    { Tag.create!(:title => 'bar') }
-  let(:tag3)    { Tag.create!(:title => 'fubar') }
-  let(:ids)     { [] }
-  let(:total)   { names.count }
   let(:page_size)   { 10 }
+  let!(:vendor1) { Vendor.create!(:name => "ven d'or", :active => true, :description => "blarg") }
+  let!(:vendor2) { Vendor.create!(:name => 'producer', :active => true, :description => "vendor extrordinare") }
+  let!(:tag2)    { Tag.create!(:title => 'bar') }
+  let!(:tag3)    { Tag.create!(:title => 'fubar') }
+  let!(:ids)     { [] }
+  let!(:total)   { names.count }
+  let!(:page_size)   { 10 }
 
   before do
     names.each_with_index {|n,i| Product.create!(:title => n, :active => true, :price => 10.0+i,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,17 @@ require 'capybara/rspec'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
-  config.use_transactional_examples = true
-  DatabaseCleaner.strategy = :transaction
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,12 +11,6 @@ require 'capybara/rspec'
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.start
-  end
-
-  config.after(:suite) do
-    DatabaseCleaner.clean
-  end
+  config.use_transactional_examples = true
+  DatabaseCleaner.strategy = :transaction
 end


### PR DESCRIPTION
Allows for compound filter fields in the form of:

``` ruby
<%= table_for @products do |t|
  t.column [:title, :description], :filter => :like, :compound_with => :or
  t.association :vendor, [:name, :description], :filter => :like, :compound_with => :and
end %>
```

Currently only joins with `OR` sql. Might be helpful to add a `compound_with` setting that would allow us to use `OR` or `AND`.

There may be weird edge cases to this addition. Not sure what not adding the like filter will do to compound conditions.

Did not add functionality for Mongoid. Would appreciate someone who knows mongo better to jump on this. Feel free to add before pulling. Opening more for discussion than anything.
